### PR TITLE
fix: correct spelling "priciples" -> "principles" in about page

### DIFF
--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -9,7 +9,7 @@ UbuCon Asia is a community-organized conference connecting Ubuntu community in A
 
 The 5th edition, UbuCon Asia 2025 will be held in St. Xavier’s College, Kathmandu, Nepal. In the weekend of Mid-September.
 
-## Code of Conduct, other priciples and policies
+## Code of Conduct, other principles and policies
 Please refer to [Code of conduct page](/code-of-conduct) for details.
 
 ## The Organizing Committee 


### PR DESCRIPTION
### **Fix typo in about page documentation**

**What changed?**

- Fixed spelling error: "priciples" → "principles" in about.mdx (line 12)

 **Why**
 - Corrects grammatical error in section heading
 - Improves documentation quality and professionalism
 - Ensures accurate spelling for conference attendees


**Type of change**
- Bug fix (typo correction)

**Files changed**
- `src/pages/about.mdx`

_Minor spelling correction in the "Code of Conduct, other principles and policies" section heading._