### PR TITLE
fix/grammar, formatting, typos in files:  about.mdx, code-of-conduct.mdx and tickets.mdx

### DIFF
--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -5,13 +5,14 @@ description: Brief introduction to UbuCon Asia 2025
 ---
 import CommitteMembers from "/src/components/CommitteeMembers.astro";
 
-UbuCon Asia is a community-organized conference connecting Ubuntu community in Asia. Join us for two days memorable of conference that connects enthusiast, engineers, creators, researchers, entrepreneurs and contributors across Asia.
+UbuCon Asia is a community-organized conference connecting the Ubuntu community across Asia. Join us for two memorable days of conference sessions that bring together enthusiasts, engineers, creators, researchers, entrepreneurs, and contributors from across the continent.
 
-The 5th edition, UbuCon Asia 2025 will be held in St. Xavier’s College, Kathmandu, Nepal. In the weekend of Mid-September.
+The 5th edition, UbuCon Asia 2025, will be held at St. Xavier’s College, Kathmandu, Nepal, during a weekend in mid-September.
 
-## Code of Conduct, other principles and policies
-Please refer to [Code of conduct page](/code-of-conduct) for details.
+## Code of Conduct, Other Principles and Policies
+Please refer to the [Code of Conduct page](/code-of-conduct) for details.
 
 ## The Organizing Committee 
-UbuCon Asia 2025 is a not-for-profit conference and a community-driven event made possible by team of volunteers from Ubuntu LoCos in Asia and other Asian FLOSS Communities.
+UbuCon Asia 2025 is a not-for-profit, community-driven event made possible by a team of volunteers from Ubuntu LoCos in Asia and other Asian FLOSS communities.
+
 <CommitteMembers/>

--- a/src/pages/code-of-conduct.mdx
+++ b/src/pages/code-of-conduct.mdx
@@ -3,24 +3,28 @@ layout: /src/layouts/MarkdownLayout.astro
 title: Code of conduct
 description: Code of conduct and violation measures information
 ---
-## Code of Conduct, other priciples and policies
+
+## Code of Conduct, other principles and policies
+
 Ubuntu Conference Asia (UbuCon Asia) is committed to a safe environment for all participants. All attendees are expected to treat all people and facilities with respect and help create a welcoming environment.
 
-To provide safe environment for every participants, We’ve adapted following Code of Conducts, priciples and other policies. All following listed documents applies to anyone participating UbuCon Asia event and required to follow. Make sure to read all listed documents regarding Code of Conduct and other policies carefully before participating. Violation of the Code of Conduct or policies may result in sanctions or expelling from the event if necessary.
+To provide a safe environment for all participants, we’ve adopted the following Codes of Conduct, principles, and other policies. All of the following documents apply to anyone participating in the UbuCon Asia event and are required to be followed. Make sure to read all listed documents regarding the Code of Conduct and other policies carefully before participating. Violation of the Code of Conduct or policies may result in sanctions or expulsion from the event if necessary.
 
 - [UbuCon Asia Code of Conduct](https://github.com/ubucon-asia/CodeOfConduct/blob/main/UbuconAsiaCodeOfConduct.md)
 - [Ubuntu Code of Conduct 2.0](https://ubuntu.com/community/ethos/code-of-conduct)
 - [Diversity Policy](https://ubuntu.com/community/ethos/diversity)
 
-If you notice behaviour that fails to meet this standard, please speak up and help to keep UbuCon Asia as respectful as we expect it to be. If you are harassed and requests to stop are not successful, or notice a disrespectful environment, the organizers want to help.
+If you notice behaviour that fails to meet this standard, please speak up and help to keep UbuCon Asia as respectful as we expect it to be. If you are harassed and requests to stop are not successful, or you notice a disrespectful environment, the organizers want to help.
 
-We will treat your request with dignity and confidentiality, investigate, and take whatever actions appropriate. We can provide information on security, emergency services, transportation, alternative accommodations, or whatever else may be necessary.
+We will treat your request with dignity and confidentiality, investigate, and take whatever actions are appropriate. We can provide information on security, emergency services, transportation, alternative accommodations, or whatever else may be necessary.
 
 ## Reporting an Incident
-### Procedure For Reporting Code of Conduct Incidents
-If you believe someone has violated Code of Conducts, we encourage you to report it. If you are unsure whether the incident is a violation, or whether the space where it happened is covered by this Code of Conduct, we encourage you to still report it. We are fine with receiving reports where we decide to take no action for the sake of creating a safer community.
 
-You can make a report by emailing coc@ubucon.asia. You may send your report using local language if you have difficulties communicating using common language (English language). For urgent matters, You may also contact one of our CoC Board members directly with matrix chat using matrix chat handles listed below. Your report will be received by the following UbuCon Asia Code of Conduct Board members:
+### Procedure For Reporting Code of Conduct Incidents
+
+If you believe someone has violated the Code of Conduct, we encourage you to report it. If you are unsure whether the incident is a violation, or whether the space where it happened is covered by this Code of Conduct, we still encourage you to report it. We are fine with receiving reports where we decide to take no action for the sake of creating a safer community.
+
+You can make a report by emailing coc@ubucon.asia. You may send your report using your local language if you have difficulties communicating using the common language (English). For urgent matters, you may also contact one of our CoC Board members directly via Matrix chat using the Matrix handles listed below. Your report will be received by the following UbuCon Asia Code of Conduct Board members:
 
 | Name | Email | Matrix chat | Role |
 | --- | --- | --- | --- |
@@ -30,9 +34,10 @@ You can make a report by emailing coc@ubucon.asia. You may send your report usin
 | Aaditya Singh | aadityasingh@gnome.org | @aadii:matrix.org | Local Team (Nepal) |
 | Sailesh Singh | sailesh36687@gmail.com | @saileshsingh:matrix.org | Local Team (Nepal) |
 
-If your report concerns one of the people listed above, please mail any of the others directly instead of using the coc@ubucon.asia list. The CoC Board has procedures to deal with such cases; please see the section “Conflicts of Interest” below.
+If your report concerns one of the people listed above, please email any of the others directly instead of using the coc@ubucon.asia list. The CoC Board has procedures to deal with such cases; please see the section “Conflicts of Interest” below.
 
 ### Report Data
+
 If you make a report via email, we hope you can provide us with some information that will help us identify the reported person. If you don’t remember all the details, we still encourage you to make a report.
 
 We encourage you to include the following information in your report:
@@ -48,15 +53,17 @@ We encourage you to include the following information in your report:
 - Other people involved in or witnesses to the incident and their contact information or description
 
 ### Confidentiality
+
 All reports will be kept confidential. When the CoC Board members discuss incidents with people who are reported, we will anonymize details as much as we can to protect reporter privacy.
 
-However, some incidents happen in one-on-one interactions, and even if the details are anonymized, the reported person may be able to guess who made the report. If you have concerns about retaliation or your personal safety, please note those in your report. We still encourage you to report, so that we can support you while keeping our community members safe. In some cases, we can compile several anonymized reports into a pattern of behavior, and take action on that pattern.
+However, some incidents happen in one-on-one interactions, and even if the details are anonymized, the reported person may be able to guess who made the report. If you have concerns about retaliation or your personal safety, please note those in your report. We still encourage you to report so that we can support you while keeping our community members safe. In some cases, we can compile several anonymized reports into a pattern of behavior and take action on that pattern.
 
-In some cases we may determine that a public statement will need to be made. If that’s the case, the identities of all people impacted by the behavior and the people who reported that behavior will remain confidential, unless those individuals instruct us otherwise.
+In some cases, we may determine that a public statement will need to be made. If that’s the case, the identities of all people impacted by the behavior and the people who reported that behavior will remain confidential unless those individuals instruct us otherwise.
 
-The CoC Board provides transparency reports about the incidents that occurred. Anonymized information from the incident you report may be included in transparency reports. Please see details in the UbuCon Asia Code of Conduct CoC Board Procedure For Incident Response.
+The CoC Board provides transparency reports about the incidents that occurred. Anonymized information from the incident you report may be included in transparency reports. Please see details in the UbuCon Asia Code of Conduct CoC Board Procedure for Incident Response.
 
 ### Report Handling Procedure
+
 When you make an incident report via email, you will receive an acknowledgment of your report within 24 hours of making the report.
 
 If the incident is ongoing and needs to be immediately addressed, any one of the CoC Board members may take appropriate action to ensure the safety of everyone involved.
@@ -64,17 +71,20 @@ If the incident is ongoing and needs to be immediately addressed, any one of the
 If the incident is less urgent, the CoC Board members will meet within 1 week to determine an appropriate response. In some cases, the CoC Board members may need to ask the person who made the report additional questions about the incident.
 
 ### Conflicts of Interest
+
 If a CoC Board member has a conflict of interest for a report, they will recuse themselves from the discussion and handling of the incident. The incident documentation will not be available to them, and they will excuse themselves from any conversations involving handling the incident.
 
-Should two or fewer CoC Board members remain to evaluate the report, A few members of UbuCon Asia Committee who are not CoC board could be invited additional decision maker on the incident. In case that is also not possible, the reported incident will be escalated to the Ubuntu Community Council.
+Should two or fewer CoC Board members remain to evaluate the report, a few members of the UbuCon Asia Committee who are not on the CoC Board may be invited as additional decision makers on the incident. If that is also not possible, the reported incident will be escalated to the Ubuntu Community Council.
 
 ### Following Up With Reporters
-Within one week of an incident report, the CoC Board will follow up with the person who made the report and provided their contact information. The follow up may include:
+
+Within one week of an incident report, the CoC Board will follow up with the person who made the report and provided their contact information. The follow-up may include:
 - An acknowledgment that the UbuCon Asia Code of Conduct Board discussed the situation
 - Whether or not the report was determined to be a violation of the Code of Conduct
 - What actions (if any) were taken to correct the reported behavior
 
-Sometimes reports take more time to discuss or follow up on. After one week of a report being open, the person who made the report will be provided with a status update. The status update will include a time frame for when the next update will be sent or the time frame in which the report is expected to be resolved.
+Sometimes, reports take more time to discuss or follow up on. After one week of a report being open, the person who made the report will be provided with a status update. The status update will include a time frame for when the next update will be sent or the time frame in which the report is expected to be resolved.
 
 ### Code of Conduct Enforcement Process 
-When handling incidents, For guidance not described in this page or within internal documentations, The UbuCon Asia CoC board will follow the [Code of Conduct Enforcement Process](https://discourse.ubuntu.com/t/code-of-conduct-enforcement-process/59844?u=sukso96100).
+
+When handling incidents, for guidance not described on this page or in internal documentation, the UbuCon Asia CoC Board will follow the [Code of Conduct Enforcement Process](https://discourse.ubuntu.com/t/code-of-conduct-enforcement-process/59844?u=sukso96100).

--- a/src/pages/tickets.mdx
+++ b/src/pages/tickets.mdx
@@ -1,44 +1,45 @@
 ---
 layout: /src/layouts/MarkdownLayout.astro
 title: Tickets
-description: Check out tickets information such as pricing and how to register for UbuCon Asia 2025.
+description: Check out ticket information such as pricing and how to register for UbuCon Asia 2025.
 ---
 import Eventbrite from "/src/components/Eventbrite.astro";
 import { WebsiteConfig } from "../config";
 
-Registration for UbuCon Asia 2025 will open soon. This year, We use different platforms depending on your payment method.
+Registration for UbuCon Asia 2025 will open soon. This year, we are using different platforms depending on your payment method.
 
 # Register 
 
-## Register with International payments
-For those who register on eventbrite with international payments, use the button below to register today.
+## Register with International Payments
+If you're registering on Eventbrite with international payment methods, use the button below to register.
 
 <Eventbrite eventbriteId={WebsiteConfig.tickets.eventbriteId} eventbriteSlug={WebsiteConfig.tickets.eventbriteSlug} />
 
-If you experience issues with payment method, We suggest you to double check if your payment methods (such as card number, your paypal account) is valid. If the payment issue persists, you may [submit a support request by clicking here.](https://www.eventbrite.com/help/en-us/contact-us/?form=all-report-event) Log-in to eventbrite may be required to submit your request.
+If you experience issues with your payment, please double-check whether your payment method (e.g., card number, PayPal account) is valid. If the problem persists, you may [submit a support request here](https://www.eventbrite.com/help/en-us/contact-us/?form=all-report-event). Logging in to Eventbrite may be required.
 
-If contacting eventbrite support does not resolve your issue, you can also contact us with [chat](https://docs.ubucon.asia/chat) or [email](mailto:contact@ubucon.asia) to ask for help.
+If contacting Eventbrite support does not resolve your issue, you can also contact us via [chat](https://docs.ubucon.asia/chat) or [email](mailto:contact@ubucon.asia) for further assistance.
 
-## Register with Local (Nepali) payments
-For those who would like to register with GNOME Nepal's platofrm with local(Nepali) payments, you can use the button below to register today.
+## Register with Local (Nepali) Payments
+If you'd like to register using GNOME Nepal’s platform with local (Nepali) payment methods, use the button below.
+
 <a href="https://nepal.gnome.org/ubucon">
     <button>Buy Tickets</button>
 </a>
+
 # Pricing
 
-| Ticket type | Price (NPR) | Price (USD) |
-| ----------- | ----------- | ----------- |
-| Early Bird  | 3500        | 35          |
-| Standard     | TBD        | TBD          |
-| Late bird* | TBD        | TBD          |
-| Student     | 2000        | 25          |
-| Individual patron | 8000-25,000           | 80-250           |
+| Ticket Type        | Price (NPR)      | Price (USD)   |
+|--------------------|------------------|----------------|
+| Early Bird         | 3,500            | 35             |
+| Standard           | TBD              | TBD            |
+| Late Bird*         | TBD              | TBD            |
+| Student            | 2,000            | 25             |
+| Individual Patron  | 8,000–25,000     | 80–250         |
 
-# What's included
+# What's Included
 
-- Access to all 2 days conference programs
+- Access to all 2-day conference programs
 - Lunch and refreshments
-- Conference swag 
+- Conference swag
 
-> *Late bird tickets only guarantees access to 2 days of conference programs, Lunch and refreshments. Conference swags are not included in this ticket type.
-
+> *Late Bird tickets only guarantee access to the 2-day conference programs, lunch, and refreshments. Conference swag is **not included** with this ticket type.


### PR DESCRIPTION
### What changed

Corrected various spelling and grammatical errors throughout about.mdx, code-of-conduct.mdx and tickets.mdx. 
Improved sentence structure and clarity for better readability and professionalism.


### Why

- 	Ensures consistency and proper grammar in the documentation
- 	Improves the professional tone of the page
- 	Enhances understanding for international readers and contributors
- 	Aligns with the project's commitment to clear communication


### Type of change

- 	Bug fix (grammar and typo correction)
- 	Documentation improvement


### Files changed

- 	src/pages/about.mdx
-       src/pages/code-of-conduct.mdx
-       src/pages/tickets.mdx

Minor spelling and grammar corrections throughout the document, including but not limited to:

-       "priciples" hanged to  "principles"
- 	"Code of Conducts" changed to "Codes of Conduct"
- 	"adapted" changed to "adopted"
- 	Sentence and paragraph structure improved for clarity and tone


